### PR TITLE
fix: make the chat pane scrollable in firefox

### DIFF
--- a/src/Components/Chat/ChatMessagesPane.js
+++ b/src/Components/Chat/ChatMessagesPane.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useRef, useEffect } from "react";
 import { makeStyles /* , useTheme */ } from "@material-ui/core/styles";
 import { Grid } from "@material-ui/core";
 import ChatMessage from "./ChatMessage";
@@ -9,23 +9,38 @@ const useStyles = makeStyles((theme) => ({
     overflow: "auto",
     flexWrap: "inherit",
   },
+  messagesContainerGrid: {
+    flex: 1,
+  },
   messageContainer: {
     width: "100%",
   },
+  shadowElement: {
+    float:"left",
+    clear: "both"
+  }
 }));
 
 export default (props) => {
+  const chatEnd = useRef(null);
   let { messages, user, users } = props;
+
+  useEffect(() => {
+    chatEnd.current.scrollIntoView({ behavior: "auto" });
+  }, [props])
 
   const classes = useStyles();
   return (
-    <Grid container direction="column-reverse" justify="flex-start" alignItems="center" className={classes.root}>
-      {messages &&
-        messages.map((message) => (
-          <Grid item key={message.messageId} className={classes.messageContainer}>
-            <ChatMessage message={message} user={user} users={users} />
-          </Grid>
-        ))}
-    </Grid>
+    <div className={classes.root}>
+      <Grid container direction="column-reverse" justify="flex-start" alignItems="center" className={classes.messagesContainerGrid} >
+        {messages &&
+          messages.map((message) => (
+            <Grid item key={message.messageId} className={classes.messageContainer}>
+              <ChatMessage message={message} user={user} users={users} />
+            </Grid>
+          ))}
+      </Grid>
+      <div className={classes.shadowElement} ref={chatEnd} />
+    </div>
   );
 };

--- a/src/Components/EventSession/EventSessionTopbar.js
+++ b/src/Components/EventSession/EventSessionTopbar.js
@@ -37,6 +37,7 @@ const useStyles = makeStyles((theme) => ({
     float: "left",
     width: 135,
     textAlign: "center",
+    whiteSpace: "nowrap",
   },
   roomButtonsContainer: {
     margin: theme.spacing(0, 4, 0, 4),


### PR DESCRIPTION
*Issue #, if available:*
#33 

*Description of changes:*
In the Firefox browser, messages were not scrollable because of [this](https://bugzilla.mozilla.org/show_bug.cgi?id=1042151) firefox bug. 
So to fix this, I wrapped the Grid in a div and made the content scroll to bottom using the `ref`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
