### PR TITLE
Fix calender invite and add dynamic timestamps

### DIFF
--- a/src/Components/Chat/ChatMessagesPane.js
+++ b/src/Components/Chat/ChatMessagesPane.js
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from "react";
+import React, { useRef, useEffect, useState } from "react";
 import { makeStyles /* , useTheme */ } from "@material-ui/core/styles";
 import { Grid } from "@material-ui/core";
 import ChatMessage from "./ChatMessage";
@@ -23,11 +23,22 @@ const useStyles = makeStyles((theme) => ({
 
 export default (props) => {
   const chatEnd = useRef(null);
-  let { messages, user, users } = props;
+  let { user, users } = props;
+
+  const [messages, setMessages] = useState([]);
 
   useEffect(() => {
+    setMessages(props.messages);
     chatEnd.current.scrollIntoView({ behavior: "auto" });
-  }, [messages])
+  }, [props.messages])
+
+
+  useEffect(() => {
+    const intervalId = setInterval(() => {
+     setMessages((mess) => [...mess])
+    }, 60 * 1000);
+    return () => clearInterval(intervalId); 
+  }, []);
 
   const classes = useStyles();
   return (

--- a/src/Components/Event/EventPage.js
+++ b/src/Components/Event/EventPage.js
@@ -87,8 +87,14 @@ export default function EventPage(props) {
   const calendarEvent = React.useMemo(() => {
     const sessionUrl = getUrl() + routes.EVENT_SESSION(id);
     let descriptionText = "";
+    let rawDescription = "";
     if (description) {
-      let descriptionContent = convertFromRaw(JSON.parse(description));
+      const parsedDescription = JSON.parse(description);
+      let descriptionContent = convertFromRaw(parsedDescription);
+      rawDescription = parsedDescription.blocks.reduce((acc, item) => {
+        acc += item.text;
+        return acc;
+      }, "");
       // descriptionText = descriptionContent.getPlainText("\n\n");
       descriptionText = stateToHTML(descriptionContent);
     }
@@ -99,6 +105,7 @@ export default function EventPage(props) {
       location: sessionUrl,
       startTime: beginDate,
       endTime: endDate,
+      rawDescription,
     };
   }, [id, description, title, beginDate, endDate]);
 

--- a/src/Components/Event/EventRegistrationForm.js
+++ b/src/Components/Event/EventRegistrationForm.js
@@ -125,8 +125,14 @@ function EventRegistrationForm(props) {
     const { id, description, title, eventBeginDate, eventEndDate } = eventSession;
     const sessionUrl = getUrl() + routes.EVENT_SESSION(id);
     let descriptionText = "";
+    let rawDescription = "";
     if (description) {
-      let descriptionContent = convertFromRaw(JSON.parse(description));
+      const parsedDescription = JSON.parse(description);
+      let descriptionContent = convertFromRaw(parsedDescription);
+      rawDescription = parsedDescription.blocks.reduce((acc, item) => {
+        acc += item.text;
+        return acc;
+      }, "");
       // descriptionText = descriptionContent.getPlainText("\n\n");
       descriptionText = stateToHTML(descriptionContent);
     }
@@ -137,6 +143,7 @@ function EventRegistrationForm(props) {
       location: sessionUrl,
       startTime: moment(eventBeginDate.toDate()),
       endTime: moment(eventEndDate.toDate()),
+      rawDescription,
     };
   }, [eventSession]);
 

--- a/src/Components/MUIAddToCalendar.js
+++ b/src/Components/MUIAddToCalendar.js
@@ -26,6 +26,8 @@ function SimpleDialog(props) {
   const classes = useStyles();
   const { onClose, selectedValue, open, event } = props;
 
+  console.log(event)
+
   const handleClose = () => {
     onClose(selectedValue);
   };
@@ -107,7 +109,7 @@ function SimpleDialog(props) {
           "END:VCALENDAR",
         ].join("\n");
     }
-
+    console.log(calendarUrl);
     return calendarUrl;
   };
 
@@ -126,7 +128,8 @@ function SimpleDialog(props) {
         ****************************************************************/
       let link = document.createElement("a");
       link.href = window.URL.createObjectURL(blob);
-      link.setAttribute(event.id, filename);
+      // link.setAttribute(event.id, filename);
+      link.setAttribute("download", filename);
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);

--- a/src/Components/MUIAddToCalendar.js
+++ b/src/Components/MUIAddToCalendar.js
@@ -26,8 +26,6 @@ function SimpleDialog(props) {
   const classes = useStyles();
   const { onClose, selectedValue, open, event } = props;
 
-  console.log(event)
-
   const handleClose = () => {
     onClose(selectedValue);
   };
@@ -97,19 +95,21 @@ function SimpleDialog(props) {
       default:
         calendarUrl = [
           "BEGIN:VCALENDAR",
+          "PRODID:-//Veertly//NONSGML EventCalender//EN",
           "VERSION:2.0",
           "BEGIN:VEVENT",
+          "UID:" + event.id,
           "URL:" + document.URL,
           "DTSTART:" + formatTime(event.startTime),
           "DTEND:" + formatTime(event.endTime),
           "SUMMARY:" + event.title,
-          "DESCRIPTION:" + event.description,
+          "DESCRIPTION:" + event.rawDescription,
+          "X-ALT-DESC;FMTTYPE=text/html:<!DOCTYPE html><html lang=\"en\"><body>"+ event.description +"</body></html>",
           "LOCATION:" + event.location,
           "END:VEVENT",
           "END:VCALENDAR",
-        ].join("\n");
+        ].join("\r\n");
     }
-    console.log(calendarUrl);
     return calendarUrl;
   };
 


### PR DESCRIPTION
*Description of changes:*
- Make `ics`  file downloadable in Safari
- Add HTML tag in `ics` file.
- Add raw description version for non-HTML supported clients
- Add dynamic timestamps.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
