### PR TITLE
Show message when there is un-compatible browser/device

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "react-beforeunload": "^2.1.0",
     "react-copy-to-clipboard": "^5.0.2",
     "react-country-flag": "^2.0.1",
+    "react-device-detect": "^1.12.1",
     "react-dom": "^16.8.0",
     "react-draggable": "^4.2.0",
     "react-firebase-file-uploader": "^2.4.3",

--- a/src/App.js
+++ b/src/App.js
@@ -33,6 +33,7 @@ import { Provider } from "react-redux";
 import store, { persistor } from "./Redux/store";
 import Routes from "./Routes";
 import Auth from "./Components/Guards/Auth";
+import DeviceDetectView from "./Components/DeviceDetectView";
 
 const theme = createMuiTheme({
   palette: {
@@ -70,15 +71,18 @@ const App = () => {
         <ThemeProvider theme={theme}>
           <SnackbarProvider SnackbarProps={{ autoHideDuration: 10000 }}>
             <CssBaseline />
-            <Router history={history}>
-              <Auth>
-                {/* <ScrollReset /> */}
-                {/* <GoogleAnalytics /> */}
-                {/* <CookiesNotification /> */}
-                {/* <SettingsNotification /> */}
-                <Routes />
-              </Auth>
-            </Router>
+              <DeviceDetectView>
+                <Router history={history}>
+                  <Auth>
+                    {/* <ScrollReset /> */}
+                    {/* <GoogleAnalytics /> */}
+                    {/* <CookiesNotification /> */}
+                    {/* <SettingsNotification /> */}
+                    <Routes />
+                  </Auth>
+                </Router>
+              </DeviceDetectView>
+            
             {/* <BrowserRouter>
               <Switch>
                 <Route exact={true} path={routes.HOME()} component={HomePage} />

--- a/src/Components/DeviceDetectView.js
+++ b/src/Components/DeviceDetectView.js
@@ -8,7 +8,7 @@ import {
   Button,
 } from "@material-ui/core";
 // import { Alert } from "@material-ui/lab";
-import { isMobileFromRdd, isChromeLike } from "../Utils/device";
+import { isMobileFromRdd, isChromeFromRRd } from "../Utils/device";
 
 const MOBILE_MSG = "Veertly is best experienced on desktop or laptop. Some features may not be available on mobile";
 const CHROME_APP = "Veertly is best experienced on Google Chrome";
@@ -21,7 +21,7 @@ const DeviceDetectView = ({ children }) => {
     if (isMobileFromRdd()) {
       setOpen(true);
       setMessage(MOBILE_MSG);
-    } else if (!isChromeLike()) {
+    } else if (!isChromeFromRRd()) {
       setOpen(true);
       setMessage(CHROME_APP);
     }

--- a/src/Components/DeviceDetectView.js
+++ b/src/Components/DeviceDetectView.js
@@ -1,0 +1,82 @@
+import React, { useState, useEffect } from "react";
+import {
+  Snackbar,
+  // Dialog,
+  // DialogActions,
+  // DialogContent,
+  // DialogContentText,
+  Button,
+} from "@material-ui/core";
+// import { Alert } from "@material-ui/lab";
+import { isMobileFromRdd, isChromeLike } from "../Utils/device";
+
+const MOBILE_MSG = "Veertly is best experienced on desktop or laptop. Some features may not be available on mobile";
+const CHROME_APP = "Veertly is best experienced on Google Chrome";
+
+const DeviceDetectView = ({ children }) => {
+  const [open, setOpen] = useState(false);
+  const [message, setMessage]= useState("");
+
+  useEffect(() => {
+    if (isMobileFromRdd()) {
+      setOpen(true);
+      setMessage(MOBILE_MSG);
+    } else if (!isChromeLike()) {
+      setOpen(true);
+      setMessage(CHROME_APP);
+    }
+  }, []);
+
+
+  // const handleClose = (eventToast, reason) => {
+  //   if (reason === "clickaway") {
+  //     return;
+  //   }
+  //   setOpen(false);
+  // };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  return (
+  <>
+    {children}
+  
+    <Snackbar
+      anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+      open={open}
+      // autoHideDuration={2000}
+      message={message}
+      // onClose={handleClose}
+      action={
+        <Button onClick={handleClose} color="secondary" >
+          OK
+        </Button>
+      }
+      />
+
+      {/* <Dialog
+        disableBackdropClick
+        disableEscapeKeyDown
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="alert-dialog-title"
+        aria-describedby="alert-dialog-description"
+      >
+        <DialogContent>
+          <DialogContentText id="alert-dialog-description">
+            {message}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleClose} color="primary">
+            Ok
+          </Button>
+        </DialogActions>
+      </Dialog> */}
+
+  </>
+)}
+
+export default DeviceDetectView;

--- a/src/Modules/firebaseApp.js
+++ b/src/Modules/firebaseApp.js
@@ -10,7 +10,7 @@ import { functions } from "firebase";
 
 var firebaseApp = firebase;
 
-const firebaseConfig = {
+export const firebaseConfig = {
   apiKey: process.env.REACT_APP_FIREBASE_API_KEY,
   authDomain: process.env.REACT_APP_FIREBASE_AUTH_DOMAIN,
   databaseURL: process.env.REACT_APP_FIREBASE_DATABASE_URL,

--- a/src/Redux/account.js
+++ b/src/Redux/account.js
@@ -1,4 +1,4 @@
-import firebase from "../Modules/firebaseApp";
+import firebase, { firebaseConfig } from "../Modules/firebaseApp";
 import {
   getUserDb,
   logoutDb,
@@ -66,6 +66,11 @@ export function loginWithGoogle() {
       const { user } = result;
       const isNewUser = result.additionalUserInfo.isNewUser;
 
+      // try out for the bug
+      if (!firebase.apps.length) {
+        firebase.initializeApp(firebaseConfig)
+      }
+      
       const userDb = isNewUser
         ? await registerNewUser(result.user)
         : await getUserDb(user.uid);

--- a/src/Utils/device.js
+++ b/src/Utils/device.js
@@ -25,3 +25,5 @@ export const isMobileFromRdd = () => isMobileRdd;
 export const isChromeLike = () => {
   return isChrome || isChromium;
 }
+
+export const isChromeFromRRd = () => isChrome;

--- a/src/Utils/device.js
+++ b/src/Utils/device.js
@@ -1,3 +1,5 @@
+import { isChrome, isChromium, isMobile as isMobileRdd } from "react-device-detect";
+
 // determine if a mobile browser is being used
 export const isMobile = () => {
   let mobile = false;
@@ -17,3 +19,9 @@ export const isMobile = () => {
 
   return mobile;
 };
+
+export const isMobileFromRdd = () => isMobileRdd;
+
+export const isChromeLike = () => {
+  return isChrome || isChromium;
+}


### PR DESCRIPTION
*Description of changes:*
- This will show a snack bar when the user is a non-chrome or mobile browser.
- This is showing currently snack bar, but we can try with dialog, just need to uncomment the code. I thought Snackbar looked better.
- It will be shown after every refresh because we are not tracking it with persistence.

- Also, This might fix the login related bug on macOS full screen.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
