### PR TITLE
Move slack webhook, send grid and base_url to variables

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -67,7 +67,7 @@ jobs:
         run: firebase use --token ${{ secrets.STAGE_FIREBASE_DEPLOY_KEY }} ${{ secrets.PROD_REACT_APP_FIREBASE_PROJECT_ID }}
 
       - name: Set firebase config
-        run: firebase --token ${{ secrets.STAGE_FIREBASE_DEPLOY_KEY }} functions:config:set global.base_url="${{ secrets.PROD_REACT_APP_FIREBASE_BASE_URL }}" slack.webhook="${{ secrets.PROD_SLACK_WEBHOOK }}" sendgrid.key="${{ secrets.SENDGRID_KEY }}"
+        run: firebase --token ${{ secrets.STAGE_FIREBASE_DEPLOY_KEY }} functions:config:set global.base_url="${{ secrets.PROD_REACT_APP_FIREBASE_BASE_URL }}" slack.webhook="${{ secrets.SLACK_WEBHOOK }}" sendgrid.key="${{ secrets.SENDGRID_KEY }}"
 
       - name: Deploy functions
         run: firebase deploy --token ${{ secrets.STAGE_FIREBASE_DEPLOY_KEY }} --only functions

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Deploy hosting
         run: |
-          firebase use --token ${{ secrets.PROD_FIREBASE_DEPLOY_KEY }} veertly
+          firebase use --token ${{ secrets.PROD_FIREBASE_DEPLOY_KEY }} ${{ secrets.PROD_REACT_APP_FIREBASE_PROJECT_ID }}
           firebase deploy -m "Deployed from github actions (${{ github.run_id }}) by ${{ github.actor }}" --token ${{ secrets.PROD_FIREBASE_DEPLOY_KEY }} --only hosting
 
   functions:
@@ -64,11 +64,10 @@ jobs:
         working-directory: ./functions
 
       - name: Select firebase project
-        run: firebase use --token ${{ secrets.STAGE_FIREBASE_DEPLOY_KEY }} veertly
+        run: firebase use --token ${{ secrets.STAGE_FIREBASE_DEPLOY_KEY }} ${{ secrets.PROD_REACT_APP_FIREBASE_PROJECT_ID }}
 
-      # - name: Set firebase config
-      #   run: firebase functions:config:set  global.base_url="https://app.veertly.com"
+      - name: Set firebase config
+        run: firebase --token ${{ secrets.STAGE_FIREBASE_DEPLOY_KEY }} functions:config:set global.base_url="${{ secrets.PROD_REACT_APP_FIREBASE_BASE_URL }}" slack.webhook="${{ secrets.PROD_SLACK_WEBHOOK }}" sendgrid.key="${{ secrets.SENDGRID_KEY }}"
 
-      #sendgrid.key="${{ secrets.SENDGRID_KEY }}"
       - name: Deploy functions
         run: firebase deploy --token ${{ secrets.STAGE_FIREBASE_DEPLOY_KEY }} --only functions

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -64,10 +64,10 @@ jobs:
         working-directory: ./functions
 
       - name: Select firebase project
-        run: firebase use --token ${{ secrets.STAGE_FIREBASE_DEPLOY_KEY }} ${{ secrets.PROD_REACT_APP_FIREBASE_PROJECT_ID }}
+        run: firebase use --token ${{ secrets.PROD_FIREBASE_DEPLOY_KEY }} ${{ secrets.PROD_REACT_APP_FIREBASE_PROJECT_ID }}
 
       - name: Set firebase config
-        run: firebase --token ${{ secrets.STAGE_FIREBASE_DEPLOY_KEY }} functions:config:set global.base_url="${{ secrets.PROD_REACT_APP_FIREBASE_BASE_URL }}" slack.webhook="${{ secrets.SLACK_WEBHOOK }}" sendgrid.key="${{ secrets.SENDGRID_KEY }}"
+        run: firebase --token ${{ secrets.PROD_FIREBASE_DEPLOY_KEY }} functions:config:set global.base_url="${{ secrets.PROD_FIREBASE_BASE_URL }}" slack.webhook="${{ secrets.PROD_SLACK_WEBHOOK }}" sendgrid.key="${{ secrets.PROD_SENDGRID_KEY }}"
 
       - name: Deploy functions
-        run: firebase deploy --token ${{ secrets.STAGE_FIREBASE_DEPLOY_KEY }} --only functions
+        run: firebase deploy --token ${{ secrets.PROD_FIREBASE_DEPLOY_KEY }} --only functions

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Deploy hosting
         run: |
-          firebase use --token ${{ secrets.STAGE_FIREBASE_DEPLOY_KEY }} veertly-stage
+          firebase use --token ${{ secrets.STAGE_FIREBASE_DEPLOY_KEY }} ${{ secrets.STAGE_REACT_APP_FIREBASE_PROJECT_ID }}
           firebase deploy -m "Deployed from github actions (${{ github.run_id }}) by ${{ github.actor }}" --token ${{ secrets.STAGE_FIREBASE_DEPLOY_KEY }} --only hosting
 
   functions:
@@ -67,11 +67,10 @@ jobs:
         working-directory: ./functions
 
       - name: Select firebase project
-        run: firebase use --token ${{ secrets.STAGE_FIREBASE_DEPLOY_KEY }} veertly-stage
+        run: firebase use --token ${{ secrets.STAGE_FIREBASE_DEPLOY_KEY }} ${{ secrets.STAGE_REACT_APP_FIREBASE_PROJECT_ID }}
 
-      # - name: Set firebase config
-      #   run: firebase functions:config:set  global.base_url="https://stage.veertly.com"
+      - name: Set firebase config
+        run: firebase --token ${{ secrets.STAGE_FIREBASE_DEPLOY_KEY }} functions:config:set global.base_url="${{ secrets.STAGE_REACT_APP_FIREBASE_BASE_URL }}" slack.webhook="${{ secrets.STAGE_SLACK_WEBHOOK }}" sendgrid.key="${{ secrets.STAGE_SENDGRID_KEY }}"
 
-      #sendgrid.key="${{ secrets.SENDGRID_KEY }}"
       - name: Deploy functions
         run: firebase deploy --token ${{ secrets.STAGE_FIREBASE_DEPLOY_KEY }} --only functions

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -70,7 +70,7 @@ jobs:
         run: firebase use --token ${{ secrets.STAGE_FIREBASE_DEPLOY_KEY }} ${{ secrets.STAGE_REACT_APP_FIREBASE_PROJECT_ID }}
 
       - name: Set firebase config
-        run: firebase --token ${{ secrets.STAGE_FIREBASE_DEPLOY_KEY }} functions:config:set global.base_url="${{ secrets.STAGE_REACT_APP_FIREBASE_BASE_URL }}" slack.webhook="${{ secrets.STAGE_SLACK_WEBHOOK }}" sendgrid.key="${{ secrets.STAGE_SENDGRID_KEY }}"
+        run: firebase --token ${{ secrets.STAGE_FIREBASE_DEPLOY_KEY }} functions:config:set global.base_url="${{ secrets.STAGE_REACT_APP_FIREBASE_BASE_URL }}" slack.webhook="${{ secrets.SLACK_WEBHOOK }}" sendgrid.key="${{ secrets.SENDGRID_KEY }}"
 
       - name: Deploy functions
         run: firebase deploy --token ${{ secrets.STAGE_FIREBASE_DEPLOY_KEY }} --only functions

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -70,7 +70,7 @@ jobs:
         run: firebase use --token ${{ secrets.STAGE_FIREBASE_DEPLOY_KEY }} ${{ secrets.STAGE_REACT_APP_FIREBASE_PROJECT_ID }}
 
       - name: Set firebase config
-        run: firebase --token ${{ secrets.STAGE_FIREBASE_DEPLOY_KEY }} functions:config:set global.base_url="${{ secrets.STAGE_REACT_APP_FIREBASE_BASE_URL }}" slack.webhook="${{ secrets.SLACK_WEBHOOK }}" sendgrid.key="${{ secrets.SENDGRID_KEY }}"
+        run: firebase --token ${{ secrets.STAGE_FIREBASE_DEPLOY_KEY }} functions:config:set global.base_url="${{ secrets.STAGE_FIREBASE_BASE_URL }}" slack.webhook="${{ secrets.STAGE_SLACK_WEBHOOK }}" sendgrid.key="${{ secrets.STAGE_SENDGRID_KEY }}"
 
       - name: Deploy functions
         run: firebase deploy --token ${{ secrets.STAGE_FIREBASE_DEPLOY_KEY }} --only functions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,7 @@ jobs:
         run: firebase use --token ${{ secrets.STAGE_FIREBASE_DEPLOY_KEY }} ${{ secrets.TEST_REACT_APP_FIREBASE_PROJECT_ID }}
 
       - name: Set firebase config
-        run: firebase  --token ${{ secrets.STAGE_FIREBASE_DEPLOY_KEY }} functions:config:set global.base_url="${{ secrets.TEST_REACT_APP_FIREBASE_BASE_URL }}" slack.webhook="${{ secrets.TEST_SLACK_WEBHOOK }}" sendgrid.key="${{ secrets.TEST_SENDGRID_KEY }}"
+        run: firebase  --token ${{ secrets.STAGE_FIREBASE_DEPLOY_KEY }} functions:config:set global.base_url="${{ secrets.TEST_REACT_APP_FIREBASE_BASE_URL }}" slack.webhook="${{ secrets.SLACK_WEBHOOK }}" sendgrid.key="${{ secrets.SENDGRID_KEY }}"
 
       - name: Deploy functions
         run: firebase deploy --token ${{ secrets.STAGE_FIREBASE_DEPLOY_KEY }} --only functions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Deploy hosting
         run: |
-          firebase use --token ${{ secrets.STAGE_FIREBASE_DEPLOY_KEY }} veertly-testing
+          firebase use --token ${{ secrets.STAGE_FIREBASE_DEPLOY_KEY }} ${{ secrets.TEST_REACT_APP_FIREBASE_PROJECT_ID }}
           firebase deploy -m "Deployed from github actions (${{ github.run_id }}) by ${{ github.actor }}" --token ${{ secrets.STAGE_FIREBASE_DEPLOY_KEY }} --only hosting
 
   functions:
@@ -67,11 +67,10 @@ jobs:
         working-directory: ./functions
 
       - name: Select firebase project
-        run: firebase use --token ${{ secrets.STAGE_FIREBASE_DEPLOY_KEY }} veertly-testing
+        run: firebase use --token ${{ secrets.STAGE_FIREBASE_DEPLOY_KEY }} ${{ secrets.TEST_REACT_APP_FIREBASE_PROJECT_ID }}
 
-      # - name: Set firebase config
-      #   run: firebase functions:config:set  global.base_url="https://stage.veertly.com"
+      - name: Set firebase config
+        run: firebase  --token ${{ secrets.STAGE_FIREBASE_DEPLOY_KEY }} functions:config:set global.base_url="${{ secrets.TEST_REACT_APP_FIREBASE_BASE_URL }}" slack.webhook="${{ secrets.TEST_SLACK_WEBHOOK }}" sendgrid.key="${{ secrets.TEST_SENDGRID_KEY }}"
 
-      #sendgrid.key="${{ secrets.SENDGRID_KEY }}"
       - name: Deploy functions
         run: firebase deploy --token ${{ secrets.STAGE_FIREBASE_DEPLOY_KEY }} --only functions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,7 @@ jobs:
         run: firebase use --token ${{ secrets.STAGE_FIREBASE_DEPLOY_KEY }} ${{ secrets.TEST_REACT_APP_FIREBASE_PROJECT_ID }}
 
       - name: Set firebase config
-        run: firebase  --token ${{ secrets.STAGE_FIREBASE_DEPLOY_KEY }} functions:config:set global.base_url="${{ secrets.TEST_REACT_APP_FIREBASE_BASE_URL }}" slack.webhook="${{ secrets.SLACK_WEBHOOK }}" sendgrid.key="${{ secrets.SENDGRID_KEY }}"
+        run: firebase  --token ${{ secrets.STAGE_FIREBASE_DEPLOY_KEY }} functions:config:set global.base_url="${{ secrets.TEST_FIREBASE_BASE_URL }}" slack.webhook="${{ secrets.TEST_SLACK_WEBHOOK }}" sendgrid.key="${{ secrets.TEST_SENDGRID_KEY }}"
 
       - name: Deploy functions
         run: firebase deploy --token ${{ secrets.STAGE_FIREBASE_DEPLOY_KEY }} --only functions


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:*
- Replace deploy project id by variable for better deployment of forks as it is already available in the env.
- Set `global.base_url`, `slack.webhook` and `sendgrid.key` using env variables and set them in the build config to avoid manual setting of config.

Note: We'll need to set the below env variables for GitHub actions before merging the PR

`PROD_REACT_APP_FIREBASE_BASE_URL=https://app.veertly.com`
`STAGE_REACT_APP_FIREBASE_BASE_URL=https://stage.veertly.com`
`TEST_REACT_APP_FIREBASE_BASE_URL=https://stage.veertly.com`
`SLACK_WEBHOOK=`
`SENDGRID_KEY=`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
